### PR TITLE
Add function to set interface to be non-blocking without using tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["tokio"]
-tokio = ["futures", "libc", "mio", "tokio-core"]
+tokio = ["futures", "mio", "tokio-core"]
 
 [build-dependencies]
 cc = "~1"
 
 [dependencies]
 futures = { version = "~0.1", optional = true }
-libc = { version = "~0.2", optional = true }
+libc = { version = "~0.2" }
 mio = { version = "~0.6", optional = true }
 tokio-core = { version = "~0.1", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,14 +17,14 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["tokio"]
-tokio = ["futures", "mio", "tokio-core"]
+tokio = ["futures", "libc", "mio", "tokio-core"]
 
 [build-dependencies]
 cc = "~1"
 
 [dependencies]
 futures = { version = "~0.1", optional = true }
-libc = { version = "~0.2" }
+libc = { version = "~0.2", optional = true }
 mio = { version = "~0.6", optional = true }
 tokio-core = { version = "~0.1", optional = true }
 

--- a/src/async.rs
+++ b/src/async.rs
@@ -10,7 +10,6 @@ use std::io::{Error, ErrorKind, Read, Result, Write};
 use std::os::unix::io::AsRawFd;
 
 use self::futures::{Async as FAsync, AsyncSink, Sink, StartSend, Stream, Poll as FPoll};
-use self::libc::c_int;
 use self::mio::{Evented, Poll as MPoll, PollOpt, Ready, Token};
 use self::mio::unix::EventedFd;
 use self::tokio_core::reactor::{Handle, PollEvented};
@@ -88,17 +87,11 @@ impl Async {
     /// # }
     /// ```
     pub fn new(iface: Iface, handle: &Handle) -> Result<Self> {
-        let fd = iface.as_raw_fd();
-        let mut nonblock: c_int = 1;
-        let result = unsafe { libc::ioctl(fd, libc::FIONBIO, &mut nonblock) };
-        if result == -1 {
-            Err(Error::last_os_error())
-        } else {
-            Ok(Async {
-                mio: PollEvented::new(MioWrapper { iface }, handle)?,
-                recv_bufsize: 1542,
-            })
-        }
+        iface.set_non_blocking(true)?;
+        Ok(Async {
+            mio: PollEvented::new(MioWrapper { iface }, handle)?,
+            recv_bufsize: 1542,
+        })
     }
     /// Sets the receive buffer size.
     ///

--- a/src/async.rs
+++ b/src/async.rs
@@ -87,7 +87,7 @@ impl Async {
     /// # }
     /// ```
     pub fn new(iface: Iface, handle: &Handle) -> Result<Self> {
-        iface.set_non_blocking(true)?;
+        iface.set_non_blocking()?;
         Ok(Async {
             mio: PollEvented::new(MioWrapper { iface }, handle)?,
             recv_bufsize: 1542,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -216,7 +216,7 @@ impl Iface {
     pub fn send(&self, buf: &[u8]) -> Result<usize> {
         (&self.fd).write(buf)
     }
-    /// Sets the interface to be blocking (default) or non-blocking
+    /// Sets the interface to be non-blocking
     ///
     /// Note the behaviour of [`send`](#method.send) and [`recv`](#method.recv) will change if set.
     ///
@@ -227,9 +227,9 @@ impl Iface {
     /// # Notes
     /// If default features are excluded, include feature "libc" for this function to be available
     #[cfg(feature = "libc")]
-    pub fn set_non_blocking(&self, non_blocking: bool) -> Result<()> {
+    pub fn set_non_blocking(&self) -> Result<()> {
         let fd = self.as_raw_fd();
-        let mut nonblock: c_int = if non_blocking { 1 } else { 0 };
+        let mut nonblock: c_int = 1;
         let result = unsafe { libc::ioctl(fd, libc::FIONBIO, &mut nonblock) };
         if result == -1 {
             Err(Error::last_os_error())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,7 +177,7 @@ impl Iface {
     /// the content of the packet is copied into the provided buffer.
     ///
     /// If interface has been set to be non-blocking, this will fail with an error of kind
-    /// [`WouldBlock`](std::io::error::ErrorKind::WouldBlock) instead of blocking
+    /// [`WouldBlock`](std::io::ErrorKind::WouldBlock) instead of blocking
     /// if no packet is queued up.
     ///
     /// Make sure the buffer is large enough. It is MTU of the interface (usually 1500, unless
@@ -196,7 +196,7 @@ impl Iface {
     /// (with appropriate headers).
     ///
     /// If interface has been set to be non-blocking, this will fail with an error of kind
-    /// [`WouldBlock`](std::io::error::ErrorKind::WouldBlock) instead of blocking
+    /// [`WouldBlock`](std::io::ErrorKind::WouldBlock) instead of blocking
     /// if interface is not ready.
     ///
     /// It is up to the caller to provide only packets that fit MTU.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,6 +223,10 @@ impl Iface {
     /// # Errors
     ///
     /// This fails with an error in case of low-level OS errors (they shouldn't usually happen).
+    ///
+    /// # Notes
+    /// If default features are excluded, include feature "libc" for this function to be available
+    #[cfg(feature = "libc")]
     pub fn set_non_blocking(&self, non_blocking: bool) -> Result<()> {
         let fd = self.as_raw_fd();
         let mut nonblock: c_int = if non_blocking { 1 } else { 0 };


### PR DESCRIPTION
Currently the only way to configure the interface to be non-blocking is by using the included tokio wrapper or calling the appropriate ioctl on the raw fd manually.

This simply extracts the ioctl call from the Async constructor into a public function. It also allows setting a non-blocking interface back to blocking.

This does require libc to be present in all builds, alternatively the function could be moved into the async module, although that may defeat the point of avoiding pulling in tokio and all its dependencies.