### PR TITLE
Tokio v1

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+	"name": "Rust",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+
+	"runArgs": ["--privileged"]
+
+	// Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+	// "mounts": [
+	// 	{
+	// 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+	// 		"target": "/usr/local/cargo",
+	// 		"type": "volume"
+	// 	}
+	// ]
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "rustc --version",
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,5 @@ tokio-core = { version = "~0.1", optional = true }
 
 [dev-dependencies]
 version-sync = "~0.9"
-etherparse = "~0.9"
-serial_test = "~0.4"
+etherparse = "~0.13"
+serial_test = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "tun-tap"
 # Also don't forget to update the version in the html_root_url attribute in src/lib.rs
 version = "0.1.4"
+edition = "2021"
 authors = ["Michal 'vorner' Vaner <vorner@vorner.cz>"]
 description = "TUN/TAP interface wrapper"
 documentation = "https://docs.rs/tun-tap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,18 +18,22 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["tokio"]
-tokio = ["futures", "libc", "mio", "tokio-core"]
+tokio = ["futures", "libc", "tokio-util", "dep:tokio"]
 
 [build-dependencies]
 cc = "~1"
 
 [dependencies]
-futures = { version = "~0.1", optional = true }
+futures = { version = "~0.3", default-features = false, optional = true }
 libc = { version = "~0.2", optional = true }
-mio = { version = "~0.6", optional = true }
-tokio-core = { version = "~0.1", optional = true }
+tokio = { package = "tokio", version = "~1.29", features = ["io-util", "net"], optional = true }
+tokio-util = {version = "~0.7", features = ["codec"], optional = true }
 
 [dev-dependencies]
 version-sync = "~0.9"
 etherparse = "~0.13"
 serial_test = "2"
+tokio = { package = "tokio", version = "~1.29", features = ["full"] }
+futures-util = "0.3.29"
+bytes = "1.5.0"
+tokio-util = {version = "~0.7", features = ["codec", "net"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["tokio"]
-tokio = ["futures", "libc", "tokio-util", "dep:tokio"]
+tokio = ["futures", "libc", "dep:tokio"]
 
 [build-dependencies]
 cc = "~1"
@@ -26,14 +26,13 @@ cc = "~1"
 [dependencies]
 futures = { version = "~0.3", default-features = false, optional = true }
 libc = { version = "~0.2", optional = true }
-tokio = { package = "tokio", version = "~1.29", features = ["io-util", "net"], optional = true }
-tokio-util = {version = "~0.7", features = ["codec"], optional = true }
+tokio = {version = "~1.29", features = ["io-util", "net"], optional = true }
 
 [dev-dependencies]
 version-sync = "~0.9"
 etherparse = "~0.13"
 serial_test = "2"
-tokio = { package = "tokio", version = "~1.29", features = ["full"] }
+tokio = {version = "~1.29", features = ["full"] }
 futures-util = "0.3.29"
 bytes = "1.5.0"
 tokio-util = {version = "~0.7", features = ["codec", "net"]}

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ sh tests/clean.sh
 
 Sudo permission is required.
 
+## MSRV
+The current MSRV(minimum supported rust version) is 1.60.
+
 ## License
 
 Licensed under either of

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -8,24 +8,25 @@
 //!
 //! You really do want better error handling than all these unwraps.
 
-extern crate futures;
-extern crate tokio_core;
-extern crate tun_tap;
-
+use bytes::Bytes;
+use futures_util::stream::StreamExt;
+use futures_util::SinkExt;
 use std::process::Command;
 use std::time::Duration;
+use tokio::time::sleep;
+use tokio_util::codec::{BytesCodec, Decoder};
 
-use futures::{Future, Stream};
-use tokio_core::reactor::{Core, Interval};
-use tun_tap::{Iface, Mode};
 use tun_tap::r#async::Async;
+use tun_tap::{Iface, Mode};
 
 /// The packet data. Note that it is prefixed by 4 bytes ‒ two bytes are flags, another two are
 /// protocol. 8, 0 is IPv4, 134, 221 is IPv6. <https://en.wikipedia.org/wiki/EtherType#Examples>.
-const PING: &[u8] = &[0, 0, 8, 0, 69, 0, 0, 84, 44, 166, 64, 0, 64, 1, 247, 40, 10, 107, 1, 2, 10,
-    107, 1, 3, 8, 0, 62, 248, 19, 160, 0, 2, 232, 228, 34, 90, 0, 0, 0, 0, 216, 83, 3, 0, 0, 0, 0,
-    0, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
-    39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55];
+const PING: &[u8] = &[
+    0, 0, 8, 0, 69, 0, 0, 84, 44, 166, 64, 0, 64, 1, 247, 40, 10, 107, 1, 2, 10, 107, 1, 3, 8, 0,
+    62, 248, 19, 160, 0, 2, 232, 228, 34, 90, 0, 0, 0, 0, 216, 83, 3, 0, 0, 0, 0, 0, 16, 17, 18,
+    19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42,
+    43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
+];
 
 /// Run a shell command. Panic if it fails in any way.
 fn cmd(cmd: &str, args: &[&str]) {
@@ -35,29 +36,30 @@ fn cmd(cmd: &str, args: &[&str]) {
         .unwrap()
         .wait()
         .unwrap();
-    assert!(ecode.success(), "Failed to execte {}", cmd);
+    assert!(ecode.success(), "Failed to execute {}", cmd);
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let iface = Iface::new("testtun%d", Mode::Tun).unwrap();
     eprintln!("Iface: {:?}", iface);
     // Configure the „local“ (kernel) endpoint. Kernel is (the host) 10.107.1.3, we (the app)
     // pretend to be 10.107.1.2.
     cmd("ip", &["addr", "add", "dev", iface.name(), "10.107.1.3/24"]);
     cmd("ip", &["link", "set", "up", "dev", iface.name()]);
-    let mut core = Core::new().unwrap();
-    let iface = Async::new(iface, &core.handle()).unwrap();
-    let (sink, stream) = iface.split();
-    let writer = Interval::new(Duration::from_secs(1), &core.handle())
-        .unwrap()
-        .map(|_| {
+
+    let iface = Async::new(iface).unwrap();
+    let (mut sink, mut stream) = BytesCodec::new().framed(iface).split();
+
+    tokio::spawn(async move {
+        loop {
+            sleep(Duration::from_secs(1)).await;
             println!("Sending ping");
-            PING.to_owned()
-        })
-        .forward(sink);
-    let reader = stream.for_each(|packet| {
-        println!("Received: {:?}", packet);
-        Ok(())
+            let _ = sink.send(Bytes::from(PING)).await;
+        }
     });
-    core.run(reader.join(writer)).unwrap();
+
+    while let Some(Ok(packet)) = stream.next().await {
+        println!("Received: {:?}", packet);
+    }
 }

--- a/examples/tokio.rs
+++ b/examples/tokio.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 use futures::{Future, Stream};
 use tokio_core::reactor::{Core, Interval};
 use tun_tap::{Iface, Mode};
-use tun_tap::async::Async;
+use tun_tap::r#async::Async;
 
 /// The packet data. Note that it is prefixed by 4 bytes ‒ two bytes are flags, another two are
 /// protocol. 8, 0 is IPv4, 134, 221 is IPv6. <https://en.wikipedia.org/wiki/EtherType#Examples>.

--- a/examples/vpn.rs
+++ b/examples/vpn.rs
@@ -25,7 +25,7 @@ use tokio_core::net::{UdpCodec, UdpSocket};
 use tokio_core::reactor::Core;
 
 use tun_tap::{Iface, Mode};
-use tun_tap::async::Async;
+use tun_tap::r#async::Async;
 
 struct VecCodec(SocketAddr);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ use std::os::raw::{c_char, c_int};
 use std::os::unix::io::{AsRawFd, IntoRawFd, RawFd};
 
 #[cfg(feature = "tokio")]
-pub mod async;
+pub mod r#async;
 
 extern "C" {
     fn tuntap_setup(fd: c_int, name: *mut u8, mode: c_int, packet_info: c_int) -> c_int;
@@ -140,7 +140,14 @@ impl Iface {
         name_buffer.extend_from_slice(ifname.as_bytes());
         name_buffer.extend_from_slice(&[0; 33]);
         let name_ptr: *mut u8 = name_buffer.as_mut_ptr();
-        let result = unsafe { tuntap_setup(fd.as_raw_fd(), name_ptr, mode as c_int, if packet_info { 1 } else { 0 }) };
+        let result = unsafe {
+            tuntap_setup(
+                fd.as_raw_fd(),
+                name_ptr,
+                mode as c_int,
+                if packet_info { 1 } else { 0 },
+            )
+        };
         if result < 0 {
             return Err(Error::last_os_error());
         }
@@ -149,11 +156,7 @@ impl Iface {
                 .to_string_lossy()
                 .into_owned()
         };
-        Ok(Iface {
-            fd,
-            mode,
-            name,
-        })
+        Ok(Iface { fd, mode, name })
     }
 
     /// Returns the mode of the adapter.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,7 +22,7 @@ fn it_sents_packets() {
     assert_eq!(num, 38);
     let packet = &buf[..num];
     if let PacketHeaders {
-        ip: Some(IpHeader::Version4(ip_header)),
+        ip: Some(IpHeader::Version4(ip_header, _)),
         transport: Some(TransportHeader::Udp(udp_header)),
         payload,
         ..


### PR DESCRIPTION
This is pretty big changes to async part of API and I'm noob in tokio infrastructure, so it's definitely needs a picky review and further testing.

I tested it only in devcontainer on aarch64 so long.

VPN example turned out to be tricky to adapt, so I'll do it later.

MSRV changed to 1.60 because of 'version-sink' crate.


TODO: 
- update vpn example
- improve docs
- async integration tests
- more examples