### PR TITLE
fix typo in doc comment

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! * It is tested only on Linux and probably doesn't work anywhere else, even though other systems
 //!   have some TUN/TAP support. Reports that it works (or not) and pull request to add other
-//!   sustem's support are welcome.
+//!   system's support are welcome.
 //! * The [`Async`](async/struct.Async.html) interface is very minimal and will require extention
 //!   for further use cases and better performance.
 //! * This doesn't support advanced usage patters, like reusing already created device or creating
@@ -140,7 +140,14 @@ impl Iface {
         name_buffer.extend_from_slice(ifname.as_bytes());
         name_buffer.extend_from_slice(&[0; 33]);
         let name_ptr: *mut u8 = name_buffer.as_mut_ptr();
-        let result = unsafe { tuntap_setup(fd.as_raw_fd(), name_ptr, mode as c_int, if packet_info { 1 } else { 0 }) };
+        let result = unsafe {
+            tuntap_setup(
+                fd.as_raw_fd(),
+                name_ptr,
+                mode as c_int,
+                if packet_info { 1 } else { 0 },
+            )
+        };
         if result < 0 {
             return Err(Error::last_os_error());
         }
@@ -149,11 +156,7 @@ impl Iface {
                 .to_string_lossy()
                 .into_owned()
         };
-        Ok(Iface {
-            fd,
-            mode,
-            name,
-        })
+        Ok(Iface { fd, mode, name })
     }
 
     /// Returns the mode of the adapter.


### PR DESCRIPTION
## what
This PR fixes a small  typo in doc comment in `src/lib.rs`. 
Along with that there is a small formatting changes.

You can make the changes in any of your existing changes and close this.


