### PR TITLE
Fix cmd function to accept arbitrary commands

### DIFF
--- a/examples/dump_iface.rs
+++ b/examples/dump_iface.rs
@@ -12,7 +12,7 @@ use tun_tap::{Iface, Mode};
 
 /// Run a shell command. Panic if it fails in any way.
 fn cmd(cmd: &str, args: &[&str]) {
-    let ecode = Command::new("ip")
+    let ecode = Command::new(cmd)
         .args(args)
         .spawn()
         .unwrap()


### PR DESCRIPTION
Modify the cmd function to allow execution of any command instead of being limited to the hardcoded "ip" command.